### PR TITLE
Treat blank env vars as unset

### DIFF
--- a/cattle/__init__.py
+++ b/cattle/__init__.py
@@ -18,7 +18,10 @@ except:
 def default_value(name, default):
     if name in CONFIG_OVERRIDE:
         return CONFIG_OVERRIDE[name]
-    return os.environ.get('CATTLE_%s' % name, default)
+    result = os.environ.get('CATTLE_%s' % name, default)
+    if result == '':
+        return default
+    return result
 
 
 _SCHEMAS = '/schemas'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,32 @@
+from cattle import default_value, Config
+import uuid
+import os
+
+
+def test_default_value():
+    # evn var is unset, return default
+    var_name = uuid.uuid4().hex
+    cattlefied_var_name = 'CATTLE_{}'.format(var_name)
+    default = 'defaulted'
+    actual = default_value(var_name, default)
+    assert default == actual
+
+    # default is explicitly blank, return blank
+    actual = default_value(var_name, '')
+    assert '' == actual
+
+    # env var is set to blank, return default
+    os.environ[cattlefied_var_name] = ''
+    actual = default_value(var_name, default)
+    assert default == actual
+
+    # env var is set, return env var value
+    os.environ[cattlefied_var_name] = 'foobar'
+    actual = default_value(var_name, default)
+    assert 'foobar' == actual
+
+    # for completeness, set_secret_key which hits the CONFIG_OVERRIDE
+    # code path
+    Config.set_secret_key('override')
+    actual = default_value('SECRET_KEY', default)
+    assert 'override' == actual


### PR DESCRIPTION
Beyond the unit test, the more interesting question is how this impacts the loading of environment variables.

The obvious risk would be that some piece of code is dependent upon some particular environment variable being set explicitly to blank to convey something meaningful. It would be a futile effort to track down and test all those potential touch points. Here's what I've done to mitigate:
* Reviewed all the calls default_value to see if any of the would reasonably want a blank value
* Ran the whole suite tests in python-agent
* Ran the test_docker.py in the integration tests in cattle
* Manually tested against my go-machine-service changes that may eventually pass in a blank environment variable to ensure that the blank is handled correctly in that context (interpreted as being unset).

After doing the all the above, I couldn't find any issues with making this change.