### PR TITLE
Cleaned up requirements

### DIFF
--- a/dist-requirements.txt
+++ b/dist-requirements.txt
@@ -1,5 +1,0 @@
-mako
-docker-py==1.0.0
-portalocker
-arrow
-# WebSockify is installed manually from package.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-argparse
 mako
 docker-py==1.0.0
 portalocker
-libvirt-python
-websockify
 subprocess32
+psutil
+websockify
+arrow

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -5,7 +5,14 @@ cd $(dirname $0)/..
 
 apt-get update
 apt-get install -y libvirt-bin libvirt-dev qemu-kvm python-numpy arptables genisoimage python-pip pkg-config python-dev rsync
+
 pip install --upgrade pip tox virtualenv
+
+# Switch to pip installed pip...
+/usr/local/bin/pip install --no-deps websockify
+/usr/local/bin/pip install psutil
+/usr/local/bin/pip install subprocess32
+
 
 if [ ! -x "$(which nsenter)" ]; then
     TMP=$(mktemp -d)

--- a/scripts/build
+++ b/scripts/build
@@ -3,7 +3,7 @@ set -e
 
 python_deps()
 {
-    if diff -q dist-requirements.txt dist/dist-requirements.txt >/dev/null 2>&1; then
+    if diff -q requirements.txt dist/requirements.txt >/dev/null 2>&1; then
         return 0
     fi
 
@@ -22,9 +22,10 @@ python_deps()
         rm -rf dist
     fi
 
-    pip install -t dist -r dist-requirements.txt
-    pip install --no-deps -t dist websockify
-    cp dist-requirements.txt dist
+    for req in $(grep -iv "websockify\|psutil\|subprocess32" < requirements.txt); do
+        pip install -t dist $req
+    done
+    cp requirements.txt dist
 }
 
 cd $(dirname $0)/..

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,13 +1,6 @@
-
 flake8
 setuptools
 pytest
 datadiff==1.1.5
 pytest-mock
-arrow
-
-mako
-docker-py==1.0.0
-portalocker
-
 libvirt-python

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,11 @@
 envlist=flake8, py27
 
 [testenv]
-deps=-rtest-requirements.txt
+deps=-rrequirements.txt
+     -rtest-requirements.txt
 commands=py.test --duration=20 -vv tests
 
 [testenv:flake8]
-deps=-rtest-requirements.txt
+deps=-rrequirements.txt
+     -rtest-requirements.txt
 commands = flake8 cattle tests


### PR DESCRIPTION
The requirements files were starting to require dual entry, and
for sure, the requirements.txt file was not being used. This project
currently relies on the dist-requirements.txt for installation. This
pull update makes it so that top-level dependencies are added in
dist-requirements.txt and testing tools are added to
test-requirements.txt.

argparse is not included in the new dist-requirments because it is part of python 2.7 stdlib.
