### PR TITLE
Use nsenter to process events in the agent-instance

### DIFF
--- a/cattle/plugins/docker/__init__.py
+++ b/cattle/plugins/docker/__init__.py
@@ -57,6 +57,10 @@ class DockerConfig:
         use_b2d = default_value('DOCKER_USE_BOOT2DOCKER', 'false')
         return use_b2d.lower() == 'true'
 
+    @staticmethod
+    def is_host_pidns():
+        return default_value('AGENT_PIDNS', 'container') == 'host'
+
 
 def docker_client(version=None):
     if DockerConfig.use_boot2docker_connection_env_vars():

--- a/cattle/utils.py
+++ b/cattle/utils.py
@@ -13,6 +13,7 @@ import uuid
 
 try:
     from eventlet.green.subprocess import check_output as e_check_output
+    from eventlet.green.subprocess import Popen as e_popen
 except:
     pass
 
@@ -271,6 +272,13 @@ def check_output(*popenargs, **kwargs):
             # This is in case CallProcessError doesn't have returncode, cmd,
             # or output
             raise e
+
+
+def popen(*args, **kw):
+    try:
+        return e_popen(*args, **kw)
+    except NameError:
+        return Popen(*args, **kw)
 
 
 def random_string(length=64):


### PR DESCRIPTION
Previously we would make a HTTP call to enter the container to run scripts.
Now that the python-agent can run in the PID namespace of the host we are
now able to just directly enter the namespace using nsenter.  "docker exec"
is not used because there is issues with properly handling input/output, for
example flushing and closing the input stream.