### PR TITLE
Remove psutil

### DIFF
--- a/cattle/agent/event.py
+++ b/cattle/agent/event.py
@@ -16,11 +16,6 @@ from cattle.plugins.core.publisher import Publisher
 from cattle.concurrency import Queue, Full, Empty, run, spawn
 
 
-PS_UTIL = False
-if not sys.platform.startswith("linux"):
-    import psutil
-    PS_UTIL = True
-
 log = logging.getLogger("agent")
 _STAMP_TS = None
 
@@ -65,10 +60,7 @@ def _should_run(pid):
     if pid is None:
         return True
     else:
-        if PS_UTIL:
-            return psutil.pid_exists(pid)
-        else:
-            return os.path.exists("/proc/%s" % pid)
+        return os.path.exists('/proc/%s' % pid)
 
 
 def _worker(worker_name, queue, ppid):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ portalocker
 libvirt-python
 websockify
 subprocess32
-psutil


### PR DESCRIPTION
psutil was only included to support non-Linux systems.  We are only
focusing on Linux so this will simplify things.