### PR TITLE
Don't check that containers are running in activate

### DIFF
--- a/cattle/agent/handler.py
+++ b/cattle/agent/handler.py
@@ -60,7 +60,7 @@ class BaseHandler(object):
         return resp
 
     def _do(self, req=None, check=None, result=None, lock_obj=None,
-            action=None):
+            action=None, post_check=True):
         if check():
             return self._reply(req, result())
 
@@ -72,7 +72,7 @@ class BaseHandler(object):
 
             data = result()
 
-            if not check():
+            if post_check and not check():
                 raise Exception("Operation failed")
 
             return self._reply(req, data)

--- a/cattle/compute/__init__.py
+++ b/cattle/compute/__init__.py
@@ -20,7 +20,9 @@ class BaseComputeDriver(BaseHandler):
             check=lambda: self._is_instance_active(instance, host),
             result=lambda: self._get_response_data(req, instanceHostMap),
             lock_obj=instance,
-            action=lambda: self._do_instance_activate(instance, host, progress)
+            action=lambda: self._do_instance_activate(instance, host,
+                                                      progress),
+            post_check=False
         )
 
     def instance_deactivate(self, req=None, instanceHostMap=None,


### PR DESCRIPTION
Containers can legitmately go to stopped right after starting, so the
instance_activate method should not check that it they're running after
executing the docker command.