### PR TITLE
Set the Linux context for Linux tests.

### DIFF
--- a/cattle/plugins/host_info/memory.py
+++ b/cattle/plugins/host_info/memory.py
@@ -5,7 +5,7 @@ class MemoryCollector(object):
     def __init__(self):
         self.key_map = {'memtotal': 'memTotal',
                         'memfree': 'memFree',
-                        'memvailable': 'memAvailable',
+                        'memavailable': 'memAvailable',
                         'buffers': 'buffers',
                         'cached': 'cached',
                         'swapcached': 'swapCached',

--- a/cattle/plugins/host_info/os_c.py
+++ b/cattle/plugins/host_info/os_c.py
@@ -11,8 +11,8 @@ class OSCollector(object):
         for key, value in zip(keys, values):
             if len(value) > 0:
                 data[key] = value
-        else:
-            data[key] = None
+            else:
+                data[key] = None
 
         return data
 

--- a/cattle/utils.py
+++ b/cattle/utils.py
@@ -88,9 +88,8 @@ class CadvisorAPIClient(object):
 
     def get_latest_stat(self):
         containers = self.get_stats()
-        if containers:
-            if len(containers) > 1:
-                return containers[-1]
+        if len(containers) > 1:
+            return containers[-1]
         return {}
 
     def get_stats(self):

--- a/cattle/utils.py
+++ b/cattle/utils.py
@@ -87,10 +87,17 @@ class CadvisorAPIClient(object):
         return self._get(self.url + '/containers')
 
     def get_latest_stat(self):
-        return self.get_containers()['stats'][-1]
+        containers = self.get_stats()
+        if containers:
+            if len(containers) > 1:
+                return containers[-1]
+        return {}
 
     def get_stats(self):
-        return self.get_containers()['stats']
+        containers = self.get_containers()
+        if containers:
+            return containers['stats']
+        return []
 
     def timestamp_diff(self, time_current, time_prev):
         time_current_conv = self._timestamp_convert(time_current)
@@ -110,10 +117,16 @@ class CadvisorAPIClient(object):
             return json.loads(data)
 
     def _get(self, url):
-        with closing(urllib2.urlopen(url, timeout=5)) as resp:
-            if resp.code == 200:
-                data = resp.read()
-                return self._marshall_to_python(data)
+        try:
+            with closing(urllib2.urlopen(url, timeout=5)) as resp:
+                if resp.code == 200:
+                    data = resp.read()
+                    return self._marshall_to_python(data)
+        except:
+            log.exception(
+                "Could not get stats from cAdvisor at: {0}".format(url))
+
+        return None
 
 
 def ping_include_resources(ping):

--- a/tests/test_host_info_plugin.py
+++ b/tests/test_host_info_plugin.py
@@ -30,6 +30,7 @@ def cadvisor_stats_data():
 
 @pytest.fixture()
 def host_data(mocker):
+    mocker.patch.object(platform, 'system', return_value='Linux')
     mocker.patch('os.getloadavg',
                  return_value=(1.60693359375, 1.73193359375, 1.79248046875))
 
@@ -57,6 +58,32 @@ def host_data(mocker):
     CadvisorAPIClient.get_containers.assert_called_with()
     cattle.utils.check_output.assert_called_once_with(
         ['docker', '-v'])
+
+    return data
+
+
+@pytest.fixture()
+def no_cadvisor_host_data(mocker):
+    mocker.patch.object(platform, 'system', return_value='Linux')
+    mocker.patch('os.getloadavg',
+                 return_value=(1.60693359375, 1.73193359375, 1.79248046875))
+
+    mocker.patch.object(CpuCollector,
+                        '_get_cpuinfo_data',
+                        return_value=cpuinfo_data())
+
+    mocker.patch.object(MemoryCollector,
+                        '_get_meminfo_data',
+                        return_value=meminfo_data())
+
+    mocker.patch.object(CadvisorAPIClient, '_get',
+                        return_value=None)
+
+    mocker.patch('cattle.utils.check_output',
+                 return_value='Docker version 1.4.1, build 5bc2ff8')
+
+    host = HostInfo()
+    data = host.collect_data()
 
     return data
 
@@ -117,6 +144,22 @@ def test_collect_data_diskinf(host_data):
     assert mount_point['/dev/sda1']['total'] == 28447.621
     assert mount_point['/dev/sda1']['used'] == 6869.797
     assert mount_point['/dev/sda1']['free'] == 21577.824
+
+
+def test_collect_data_bad_cadvisor_stat(no_cadvisor_host_data):
+    expected_cpuinfo_keys = ['modelName',
+                             'count',
+                             'mhz',
+                             'loadAvg',
+                             'cpuCoresPercentages'
+                             ]
+    expected_disk_info = {'mountPoints': {}}
+
+    assert sorted(no_cadvisor_host_data['cpuInfo']) == \
+        sorted(expected_cpuinfo_keys)
+    assert no_cadvisor_host_data['cpuInfo']['cpuCoresPercentages'] == []
+
+    assert no_cadvisor_host_data['diskInfo'] == expected_disk_info
 
 
 def test_collect_data_cpuinfo(host_data):


### PR DESCRIPTION
Tests were not running on a Mac directly. Turns out the errors from
cAdvisor client were causing incorrect results up the stack. I refactored the cAdvisor client code to be more resilient, and to return more sane values.