### PR TITLE
tests: update response for Docker 1.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,3 @@
-image: rancher/docker-dind-base:v0.4.1
+image: rancher/dind:v0.3.0
 script:
   - ./scripts/ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rancher/docker-dind-base:v0.4.1
+FROM rancher/dind:v0.3.0
 COPY ./scripts/bootstrap /scripts/bootstrap
 RUN /scripts/bootstrap
 WORKDIR /source

--- a/tests/docker/image_activate_resp
+++ b/tests/docker/image_activate_resp
@@ -7,6 +7,8 @@
                     "Id": "4aece5bf9124998dae604ab09a9e3d6a3a5e305c68c313198f0faca6c67a1c3f",
                     "ParentId": "c7823450b259734d52c75ad923c5501cfc24b6c6b91a7d550e2089271e7d0495",
                     "RepoTags": ["ibuildthecloud/helloworld:latest"],
+                    "RepoDigests": [],
+                    "Labels": null,
                     "Size": 0
                 }
             }

--- a/tests/docker/instance_activate_agent_instance_resp
+++ b/tests/docker/instance_activate_agent_instance_resp
@@ -12,6 +12,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_command_args_resp
+++ b/tests/docker/instance_activate_command_args_resp
@@ -12,6 +12,7 @@
                     },
                     "dockerContainer": {
                         "Command": "sleep 1 2 3",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/ca-c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_command_null_resp
+++ b/tests/docker/instance_activate_command_null_resp
@@ -12,6 +12,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c-c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_command_resp
+++ b/tests/docker/instance_activate_command_resp
@@ -12,6 +12,7 @@
                     },
                     "dockerContainer": {
                         "Command": "sleep 5",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c-c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_fields_resp
+++ b/tests/docker/instance_activate_fields_resp
@@ -11,6 +11,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_ipsec_lb_agent_resp
+++ b/tests/docker/instance_activate_ipsec_lb_agent_resp
@@ -12,6 +12,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_ipsec_network_agent_resp
+++ b/tests/docker/instance_activate_ipsec_network_agent_resp
@@ -14,6 +14,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_ipsec_resp
+++ b/tests/docker/instance_activate_ipsec_resp
@@ -14,6 +14,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_links_no_service_resp
+++ b/tests/docker/instance_activate_links_no_service_resp
@@ -12,6 +12,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_links_resp
+++ b/tests/docker/instance_activate_links_resp
@@ -12,6 +12,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_native_container_not_running_resp
+++ b/tests/docker/instance_activate_native_container_not_running_resp
@@ -9,6 +9,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/native_container"

--- a/tests/docker/instance_activate_native_container_resp
+++ b/tests/docker/instance_activate_native_container_resp
@@ -9,6 +9,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/native_container"

--- a/tests/docker/instance_activate_ports_resp
+++ b/tests/docker/instance_activate_ports_resp
@@ -11,6 +11,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_resp
+++ b/tests/docker/instance_activate_resp
@@ -12,6 +12,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_activate_volumes_resp
+++ b/tests/docker/instance_activate_volumes_resp
@@ -12,6 +12,7 @@
                     },
                     "dockerContainer": {
                         "Command": "sleep 5",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c-c861f990-4472-4fa1-960f-65171b544c28"

--- a/tests/docker/instance_deactivate_native_container_resp
+++ b/tests/docker/instance_deactivate_native_container_resp
@@ -9,6 +9,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/native_container"

--- a/tests/docker/instance_deactivate_resp
+++ b/tests/docker/instance_deactivate_resp
@@ -9,6 +9,7 @@
                     },
                     "dockerContainer": {
                         "Command": "/sleep.sh",
+                        "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"


### PR DESCRIPTION
I also notice that the response for image_activate of "Label" is none, rather than {} in other cases. Probably a bug in docker side.