### PR TITLE
Fix agent delete issue

### DIFF
--- a/cattle/plugins/docker/compute.py
+++ b/cattle/plugins/docker/compute.py
@@ -61,7 +61,7 @@ def _is_stopped(client, container):
 
 
 def _to_upper_case(key):
-            return key[0].upper() + key[1:]
+    return key[0].upper() + key[1:]
 
 
 class DockerCompute(KindBasedMixin, BaseComputeDriver):
@@ -174,16 +174,15 @@ class DockerCompute(KindBasedMixin, BaseComputeDriver):
         return id == container_id
 
     def get_container(self, client, instance):
-        try:
-            if instance.externalId is not None:
-                return self.get_container_by(client, lambda x: self._id_filter(
-                    instance.externalId, x))
-        except AttributeError:
-            pass
-
         name = '/{0}'.format(instance.uuid)
-        return self.get_container_by(client,
-                                     lambda x: self._name_filter(name, x))
+        container = self.get_container_by(client,
+                                          lambda x: self._name_filter(name, x))
+        if container:
+            return container
+
+        if hasattr(instance, 'externalId') and instance.externalId:
+            return self.get_container_by(client, lambda x: self._id_filter(
+                instance.externalId, x))
 
     def _is_instance_active(self, instance, host):
         client = self._get_docker_client(host)
@@ -220,7 +219,7 @@ class DockerCompute(KindBasedMixin, BaseComputeDriver):
                         with open(path.join(acct_client_cert_dir,
                                             'client.crt'),
                                   'w') as f:
-                                f.write(client_crt)
+                            f.write(client_crt)
                     if client_key:
                         log.debug('Writing client key')
                         with open(path.join(acct_client_cert_dir,

--- a/tests/docker/instance_activate_native_container
+++ b/tests/docker/instance_activate_native_container
@@ -81,7 +81,7 @@
                 "requestedState": null,
                 "state": "starting",
                 "type": "instance",
-                "uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                "uuid": "F5FCFDD0-8C43-451B-8670-D190E0C69DC7",
                 "volumes": [
                     {
                         "accountId": 1,

--- a/tests/docker/instance_activate_native_container_not_running
+++ b/tests/docker/instance_activate_native_container_not_running
@@ -81,7 +81,7 @@
                 "requestedState": null,
                 "state": "starting",
                 "type": "instance",
-                "uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                "uuid": "F5FCFDD0-8C43-451B-8670-D190E0C69DC7",
                 "volumes": [
                     {
                         "accountId": 1,

--- a/tests/docker/instance_activate_volumes
+++ b/tests/docker/instance_activate_volumes
@@ -120,10 +120,11 @@
                 ],
                 "dataVolumesFromContainers" : [
                     {
-                        "uuid" : "target_volumes_from_by_uuid"
+                        "uuid": "target_volumes_from_by_uuid"
                     },
                     {
-                        "externalId": "set in code"
+                        "uuid": "wont be found",
+                        "externalId": "set in test code"
                     }
                 ],
                 "zoneId": 1

--- a/tests/docker/instance_deactivate_native_container
+++ b/tests/docker/instance_deactivate_native_container
@@ -79,7 +79,7 @@
                 "requestedState": null,
                 "state": "starting",
                 "type": "instance",
-                "uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                "uuid": "F5FCFDD0-8C43-451B-8670-D190E0C69DC7",
                 "volumes": [
                     {
                         "accountId": 1,


### PR DESCRIPTION
If an agent is deleted and re-added, it doesn't get recognized
successfully by catttle. This is due to how we are looking the
container up. This fixes how we look up containers to prefer uuid over
external id.