### PR TITLE
Use labels for sys container, uuid, and ip

### DIFF
--- a/cattle/plugins/docker/__init__.py
+++ b/cattle/plugins/docker/__init__.py
@@ -40,7 +40,7 @@ class DockerConfig:
 
     @staticmethod
     def api_version():
-        return default_value('DOCKER_API_VERSION', '1.15')
+        return default_value('DOCKER_API_VERSION', '1.18')
 
     @staticmethod
     def docker_required():

--- a/cattle/plugins/docker/compute.py
+++ b/cattle/plugins/docker/compute.py
@@ -408,7 +408,7 @@ class DockerCompute(KindBasedMixin, BaseComputeDriver):
         self._setup_simple_config_fields(start_config, instance,
                                          START_CONFIG_FIELDS)
 
-        add_label(create_config, RANCHER_UUID=instance.uuid)
+        add_label(create_config, {'io.rancher.container.uuid': instance.uuid})
 
         self._setup_hostname(create_config, instance)
 
@@ -423,6 +423,8 @@ class DockerCompute(KindBasedMixin, BaseComputeDriver):
         self._setup_links(start_config, instance)
 
         self._setup_networking(instance, host, create_config, start_config)
+
+        self._flag_system_container(instance, create_config)
 
         setup_cattle_config_url(instance, create_config)
 
@@ -455,6 +457,14 @@ class DockerCompute(KindBasedMixin, BaseComputeDriver):
                 else:
                     raise
         return container
+
+    def _flag_system_container(self, instance, create_config):
+        try:
+            if instance.systemContainer:
+                add_label(create_config, {
+                    'io.rancher.container.system': instance.systemContainer})
+        except (KeyError, AttributeError):
+            pass
 
     def _setup_simple_config_fields(self, config, instance, fields):
         for src, dest in fields:

--- a/cattle/plugins/docker/network.py
+++ b/cattle/plugins/docker/network.py
@@ -43,7 +43,8 @@ def setup_mac_and_ip(instance, create_config):
                     break
 
             if ip_address:
-                add_label(create_config, RANCHER_IP=ip_address)
+                add_label(create_config,
+                          {'io.rancher.container.ip': ip_address})
     except (KeyError, AttributeError):
         pass
 

--- a/cattle/plugins/docker/util.py
+++ b/cattle/plugins/docker/util.py
@@ -36,8 +36,14 @@ def add_to_env(config, *args, **kw):
             env[k] = v
 
 
-def add_label(config, **kw):
-    add_to_env(config, **kw)
+def add_label(config, new_labels):
+    try:
+        labels = config['labels']
+    except KeyError:
+        labels = {}
+        config['labels'] = labels
+
+    labels.update(new_labels)
 
 
 def is_nonrancher_container(instance):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mako
-git+https://github.com/hibooboo2/docker-py.git@pull_auth
+docker-py==1.2.2
 portalocker
 subprocess32
 psutil

--- a/tests/docker/instance_activate_agent_instance_resp
+++ b/tests/docker/instance_activate_agent_instance_resp
@@ -28,7 +28,10 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_command
+++ b/tests/docker/instance_activate_command
@@ -90,7 +90,7 @@
                 "requestedState": null,
                 "state": "starting",
                 "type": "instance",
-                "uuid": "c-c861f990-4472-4fa1-960f-65171b544c28",
+                "uuid": "c861f990-4472-4fa1-960f-65171b544c28",
                 "volumes": [
                     {
                         "accountId": 1,

--- a/tests/docker/instance_activate_command_args
+++ b/tests/docker/instance_activate_command_args
@@ -91,7 +91,7 @@
                 "requestedState": null,
                 "state": "starting",
                 "type": "instance",
-                "uuid": "ca-c861f990-4472-4fa1-960f-65171b544c28",
+                "uuid": "c861f990-4472-4fa1-960f-65171b544c28",
                 "volumes": [
                     {
                         "accountId": 1,

--- a/tests/docker/instance_activate_command_args_resp
+++ b/tests/docker/instance_activate_command_args_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/ca-c861f990-4472-4fa1-960f-65171b544c28"
+                            "/c861f990-4472-4fa1-960f-65171b544c28"
                         ],
                         "Ports": [
                             {
@@ -28,7 +28,10 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_command_null
+++ b/tests/docker/instance_activate_command_null
@@ -90,7 +90,7 @@
                 "requestedState": null,
                 "state": "starting",
                 "type": "instance",
-                "uuid": "c-c861f990-4472-4fa1-960f-65171b544c28",
+                "uuid": "c861f990-4472-4fa1-960f-65171b544c28",
                 "volumes": [
                     {
                         "accountId": 1,

--- a/tests/docker/instance_activate_command_null_resp
+++ b/tests/docker/instance_activate_command_null_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c-c861f990-4472-4fa1-960f-65171b544c28"
+                            "/c861f990-4472-4fa1-960f-65171b544c28"
                         ],
                         "Ports": [
                             {
@@ -28,7 +28,10 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_command_resp
+++ b/tests/docker/instance_activate_command_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c-c861f990-4472-4fa1-960f-65171b544c28"
+                            "/c861f990-4472-4fa1-960f-65171b544c28"
                         ],
                         "Ports": [
                             {
@@ -28,7 +28,10 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_fields_resp
+++ b/tests/docker/instance_activate_fields_resp
@@ -21,7 +21,10 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_ipsec_lb_agent_resp
+++ b/tests/docker/instance_activate_ipsec_lb_agent_resp
@@ -28,7 +28,12 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.system": "LoadBalancerAgent",
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.ip": "10.10.10.10/24"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_ipsec_network_agent_resp
+++ b/tests/docker/instance_activate_ipsec_network_agent_resp
@@ -42,7 +42,12 @@
                                 "PrivatePort": 500,
                                 "PublicPort": 1500
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.system": "NetworkAgent",
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.ip": "10.10.10.10/24"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_ipsec_resp
+++ b/tests/docker/instance_activate_ipsec_resp
@@ -42,7 +42,11 @@
                                 "PrivatePort": 500,
                                 "PublicPort": 1500
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.ip": "10.10.10.10/24"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_links_no_service_resp
+++ b/tests/docker/instance_activate_links_no_service_resp
@@ -28,7 +28,11 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.ip": "10.10.10.10/24"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_links_resp
+++ b/tests/docker/instance_activate_links_resp
@@ -28,7 +28,11 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.ip": "10.10.10.10/24"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_ports_resp
+++ b/tests/docker/instance_activate_ports_resp
@@ -21,7 +21,11 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.ip": "10.10.10.10/24"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_resp
+++ b/tests/docker/instance_activate_resp
@@ -28,7 +28,11 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.ip": "10.10.10.10/24"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_activate_volumes
+++ b/tests/docker/instance_activate_volumes
@@ -91,7 +91,7 @@
                 "requestedState": null,
                 "state": "starting",
                 "type": "instance",
-                "uuid": "c-c861f990-4472-4fa1-960f-65171b544c28",
+                "uuid": "c861f990-4472-4fa1-960f-65171b544c28",
                 "volumes": [
                     {
                         "accountId": 1,

--- a/tests/docker/instance_activate_volumes_resp
+++ b/tests/docker/instance_activate_volumes_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c-c861f990-4472-4fa1-960f-65171b544c28"
+                            "/c861f990-4472-4fa1-960f-65171b544c28"
                         ],
                         "Ports": [
                             {
@@ -28,7 +28,10 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                        }
                     }
                 }
             }

--- a/tests/docker/instance_deactivate_resp
+++ b/tests/docker/instance_deactivate_resp
@@ -14,7 +14,11 @@
                         "Names": [
                             "/c861f990-4472-4fa1-960f-65171b544c28"
                         ],
-                        "Ports": []
+                        "Ports": [],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.ip": "10.10.10.10/24"
+                        }
                     }
                 }
             }

--- a/tests/docker/native_container_volume_remove
+++ b/tests/docker/native_container_volume_remove
@@ -103,7 +103,7 @@
               "stdinOpen": true,
               "directory": null,
               "environment": {
-                "RANCHER_NETWORK": "true"
+                "io.rancher.container.network": "true"
               },
               "command": [
                 "bash"

--- a/tests/docker/volmgr_instance_activate_volumes
+++ b/tests/docker/volmgr_instance_activate_volumes
@@ -91,7 +91,7 @@
                 "requestedState": null,
                 "state": "starting",
                 "type": "instance",
-                "uuid": "c-c861f990-4472-4fa1-960f-65171b544c28",
+                "uuid": "c861f990-4472-4fa1-960f-65171b544c28",
                 "volumes": [
                     {
                         "accountId": 1,

--- a/tests/docker/volmgr_instance_activate_volumes_resp
+++ b/tests/docker/volmgr_instance_activate_volumes_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c-c861f990-4472-4fa1-960f-65171b544c28"
+                            "/c861f990-4472-4fa1-960f-65171b544c28"
                         ],
                         "Ports": [
                             {
@@ -28,7 +28,10 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                        }
                     }
                 }
             }

--- a/tests/docker/volmgr_instance_restore_volume_resp
+++ b/tests/docker/volmgr_instance_restore_volume_resp
@@ -28,7 +28,10 @@
                                 "Type": "tcp",
                                 "PrivatePort": 8080
                             }
-                        ]
+                        ],
+                        "Labels": {
+                            "io.rancher.container.uuid": "c-5f7d6bf1-0528-439d-abca-49daf59002aa"
+                        }
                     }
                 }
             }

--- a/tests/docker_common.py
+++ b/tests/docker_common.py
@@ -87,17 +87,11 @@ def instance_only_activate(agent, responses):
     def post(req, resp):
         docker_inspect = resp['data']['instanceHostMap']['instance']['+data'][
             'dockerInspect']
-        envs = docker_inspect['Config']['Env']
-        found_ip_env = False
+        labels = docker_inspect['Config']['Labels']
         ip = req['data']['instanceHostMap']['instance']['nics'][
             0]['ipAddresses'][0]
-        expected_ip_env_var = "RANCHER_IP={0}/{1}".format(ip.address,
-                                                          ip.subnet.cidrSize)
-        for env in envs:
-            if env == expected_ip_env_var:
-                found_ip_env = True
-                break
-        assert found_ip_env
+        expected_ip = "{0}/{1}".format(ip.address, ip.subnet.cidrSize)
+        assert labels['io.rancher.container.ip'] == expected_ip
         instance_activate_common_validation(resp)
 
     event_test(agent, 'docker/instance_activate', pre_func=pre, post_func=post)

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -629,7 +629,7 @@ def test_instance_activate_agent_instance(agent, responses):
 
 @if_docker
 def test_instance_activate_volumes(agent, responses):
-    delete_container('/c-c861f990-4472-4fa1-960f-65171b544c28')
+    delete_container('/c861f990-4472-4fa1-960f-65171b544c28')
     delete_container('/target_volumes_from_by_uuid')
     delete_container('/target_volumes_from_by_id')
 
@@ -680,7 +680,7 @@ def test_instance_activate_volumes(agent, responses):
 
 @if_docker
 def test_instance_activate_null_command(agent, responses):
-    delete_container('/c-c861f990-4472-4fa1-960f-65171b544c28')
+    delete_container('/c861f990-4472-4fa1-960f-65171b544c28')
 
     def post(req, resp):
         instance_activate_common_validation(resp)
@@ -690,7 +690,7 @@ def test_instance_activate_null_command(agent, responses):
 
 @if_docker
 def test_instance_activate_command(agent, responses):
-    delete_container('/c-c861f990-4472-4fa1-960f-65171b544c28')
+    delete_container('/c861f990-4472-4fa1-960f-65171b544c28')
 
     def post(req, resp):
         instance_activate_common_validation(resp)
@@ -700,7 +700,7 @@ def test_instance_activate_command(agent, responses):
 
 @if_docker
 def test_instance_activate_command_args(agent, responses):
-    delete_container('/ca-c861f990-4472-4fa1-960f-65171b544c28')
+    delete_container('/c861f990-4472-4fa1-960f-65171b544c28')
 
     def post(req, resp):
         instance_activate_common_validation(resp)
@@ -786,7 +786,7 @@ def test_ping_stat_exception(agent, responses, mocker):
 
 @if_docker
 def test_volume_purge(agent, responses):
-    delete_container('/c-c861f990-4472-4fa1-960f-65171b544c28')
+    delete_container('/c861f990-4472-4fa1-960f-65171b544c28')
     delete_container('/target_volumes_from')
 
     client = docker_client()

--- a/tests/test_docker_volmgr.py
+++ b/tests/test_docker_volmgr.py
@@ -51,7 +51,7 @@ def _volmgr_setup(mocker):
 @if_docker
 def test_volmgr_instance_activate_volumes(agent, responses, mocker):
     _volmgr_setup(mocker)
-    delete_container('/c-c861f990-4472-4fa1-960f-65171b544c28')
+    delete_container('/c861f990-4472-4fa1-960f-65171b544c28')
 
     volmgr_mount = CONFIG_OVERRIDE["VOLMGR_MOUNT_DIR"]
     volume_uuid = "0bcc6a7f-0c46-4d06-af51-224a47deeea8"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=flake8, py27
 [testenv]
 deps=-rrequirements.txt
      -rtest-requirements.txt
-commands=py.test -x --duration=20 -vv tests
+commands=py.test -x --duration=20 -vv tests {posargs}
 
 [testenv:flake8]
 deps=-rrequirements.txt


### PR DESCRIPTION
Start using real labels instead of environment variables for RANCHER_UUID AND RANCHER_IP. And start labelling rancher system containers.

***Dont merge. This requires some coordination because it requires that we upgrade to 1.6.***
I'll coordinate with @ibuildthecloud and @cloudnautique on when it can be merged.