### PR TITLE
Refactor instance ping logic

### DIFF
--- a/tests/docker/ping_resp
+++ b/tests/docker/ping_resp
@@ -67,12 +67,19 @@
             },
             {
                 "type" : "instance",
-                "uuid" : "c861f990-4472-4fa1-960f-65171b544c28",
+                "uuid" : "uuid-running",
                 "state" : "running",
                 "image": "ibuildthecloud/helloworld:latest",
                 "systemContainer": null,
-                "labels": {"io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
-                "io.rancher.container.ip": "10.10.10.10/24"}
+                "labels": {"io.rancher.container.uuid": "uuid-running"}
+            },
+            {
+                "type" : "instance",
+                "uuid" : "uuid-stopped",
+                "state" : "stopped",
+                "image": "ibuildthecloud/helloworld:latest",
+                "systemContainer": null,
+                "labels": {"io.rancher.container.uuid": "uuid-stopped"}
             }
         ],
         "options" : {

--- a/tests/docker/ping_stat_exception_resp
+++ b/tests/docker/ping_stat_exception_resp
@@ -18,15 +18,6 @@
                 "hostUuid" : "testuuid",
                 "name" : "localhost Storage Pool",
                 "kind" : "docker"
-            },
-            {
-                "type" : "instance",
-                "uuid" : "c861f990-4472-4fa1-960f-65171b544c28",
-                "state" : "running",
-                "image": "ibuildthecloud/helloworld:latest",
-                "systemContainer": null,
-                "labels": {"io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
-                "io.rancher.container.ip": "10.10.10.10/24"}
             }
         ],
         "options" : {


### PR DESCRIPTION
Don't send containers that have been created but not started.
Change logic explicitly look for running containers and assume all
other containers are stopped (as opposed to explicitly looking for
stopped and assuming everything else is running, which is how the
previous logic worked).