### PR TITLE
Added Libraries to handle SSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ portalocker
 subprocess32
 psutil
 arrow
+ndg-httpsclient
+requests==2.7.0

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -4,13 +4,14 @@ set -e
 cd $(dirname $0)/..
 
 apt-get update
-apt-get install -y arptables python-pip python-dev rsync
+apt-get install -y arptables python-pip python-dev rsync libssl-dev libffi-dev
 
 pip install --upgrade pip tox virtualenv
 
 # Switch to pip installed pip...
 /usr/local/bin/pip install psutil
 /usr/local/bin/pip install subprocess32
+/usr/local/bin/pip install ndg-httpsclient
 
 
 if [ ! -x "$(which nsenter)" ]; then

--- a/scripts/build
+++ b/scripts/build
@@ -22,7 +22,7 @@ python_deps()
         rm -rf dist
     fi
 
-    for req in $(grep -iv "websockify\|psutil\|subprocess32" < requirements.txt); do
+    for req in $(grep -iv "websockify\|psutil\|subprocess32\|ndg-httpsclient" < requirements.txt); do
         pip install -t dist $req
     done
     cp requirements.txt dist


### PR DESCRIPTION
Agents connecting to SSL servers were unable to connect to the  server because of the way urllib3 handled connections. Adding these libraries brings the libraries up to a good working state. 

Will be submitting rancher/agent PR to make sure the libraries are in the container.

